### PR TITLE
use ffmpeg_use_atomics_fallback to avoid stdatomic compile errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Inject the settings in icecc.gni into your build config, either explicitly:
 
     gn gen out \
-      --args='use_debug_fission=false clang_use_chrome_plugins=false enable_nacl=false linux_use_bundled_binutils=false cc_wrapper="ccache"'
+      --args='use_debug_fission=false clang_use_chrome_plugins=false enable_nacl=false linux_use_bundled_binutils=false cc_wrapper="ccache" ffmpeg_use_atomics_fallback=true'
 
 Or by importing the absolute path to icecc.gni from args.gn:
 

--- a/icecc.gni
+++ b/icecc.gni
@@ -16,3 +16,4 @@ clang_use_chrome_plugins=false
 enable_nacl=false
 linux_use_bundled_binutils=false
 cc_wrapper="ccache"
+ffmpeg_use_atomics_fallback=true


### PR DESCRIPTION
clang + icecc builds make use of clang's -frewrite-includes flag,
but that flag is broken by use of #include_next.  Since this directive
is used inside chromium's clang stdatomic.h header, compilation
would fail in ffmpeg.

There is a new ffmpeg_use_atomics_fallback arg to toggle the use
of ffmpeg's atomics compat code, enabling that avoids the clang bug.

References:
https://bugs.llvm.org/show_bug.cgi?id=26828
https://chromium-review.googlesource.com/c/552120/
https://chromium-review.googlesource.com/c/553379/