### PR TITLE
Don't pass file_macro to CCACHE_SLOPPINESS

### DIFF
--- a/ccache-env
+++ b/ccache-env
@@ -4,5 +4,5 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-export CCACHE_SLOPPINESS=time_macros,include_file_mtime,file_macro
+export CCACHE_SLOPPINESS=time_macros,include_file_mtime
 export CCACHE_CPP2=yes


### PR DESCRIPTION
This option is preventing ccache from adding `__FILE__` to the file's hash. This does not work when there are multiple source files which only contain a include directive for another source file. This happens for example in Chromium's fork of ffmpeg.